### PR TITLE
API-47 Explain that the client secret never leaves the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^17.0.2",
     "react-lottie": "^1.2.3",
     "react-scripts": "4.0.3",
+    "react-tooltip": "^4.2.21",
     "styled-components": "^5.3.3",
     "swiper": "6.8.4",
     "web-vitals": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@publiqbe/openapi2postman": "^0.2.0",
     "@tailwindcss/forms": "^0.3.4",
     "@testing-library/jest-dom": "^5.11.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
+    "@fortawesome/react-fontawesome": "^0.1.16",
     "@publiqbe/openapi2postman": "^0.2.0",
     "@tailwindcss/forms": "^0.3.4",
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/Form.js
+++ b/src/Form.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { Alert } from './components/Alert';
 import { HowTo } from './components/HowTo';
 import { Spinner } from './components/Spinner';
+import { Tooltip } from './components/Tooltip';
 
 const ENVIRONMENTS = [
   {
@@ -187,7 +188,7 @@ const Form = (props) => {
                   }}
                 />
               </div>
-              <div>
+              <div style={{position: "relative"}}>
                 <input
                   type="password"
                   className="u-full-width"
@@ -198,6 +199,7 @@ const Form = (props) => {
                     resetError();
                   }}
                 />
+                <Tooltip text={"Your client secret never leaves your browser. You can also leave this empty and enter it in Postman itself as the \"oauth2ClientSecret\" variable."} />
               </div>
               <div>
                 <select

--- a/src/Form.js
+++ b/src/Form.js
@@ -188,7 +188,7 @@ const Form = (props) => {
                   }}
                 />
               </div>
-              <div style={{position: "relative"}}>
+              <div style={{ position: 'relative' }}>
                 <input
                   type="password"
                   className="u-full-width"
@@ -199,7 +199,11 @@ const Form = (props) => {
                     resetError();
                   }}
                 />
-                <Tooltip text={"Your client secret never leaves your browser. You can also leave this empty and enter it in Postman itself as the \"oauth2ClientSecret\" variable."} />
+                <Tooltip
+                  text={
+                    'Your client secret never leaves your browser. You can also leave this empty and enter it in Postman itself as the "oauth2ClientSecret" variable.'
+                  }
+                />
               </div>
               <div>
                 <select

--- a/src/Form.js
+++ b/src/Form.js
@@ -235,7 +235,7 @@ const Form = (props) => {
               )}
               {hasAdvancedSettings && (
                 <AdvancedOptions>
-                  <label htmlFor="enironment">Environment</label>
+                  <label htmlFor="environment">Environment</label>
                   <select
                     className="u-full-width"
                     value={formData.environment}

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,6 +1,6 @@
 import ReactTooltip from 'react-tooltip';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import styled from 'styled-components';
 
 const QuestionMark = styled.div`

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,0 +1,26 @@
+import ReactTooltip from 'react-tooltip';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+import styled from 'styled-components';
+
+const QuestionMark = styled.div`
+  display: inline-block;
+  color: darkgrey;
+  position: absolute;
+  right: -25px;
+  top: 5px;
+`;
+
+const Tooltip = (props) => {
+  const { text } = props;
+  return (
+    <QuestionMark>
+      <span data-tip={text}>
+        <FontAwesomeIcon icon={faQuestionCircle} />
+      </span>
+      <ReactTooltip place="bottom" type="dark" effect="solid" />
+    </QuestionMark>
+  );
+};
+
+export { Tooltip };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,12 +1325,26 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
   integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
 
+"@fortawesome/fontawesome-svg-core@^1.2.36":
+  version "1.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz#4f2ea6f778298e0c47c6524ce2e7fd58eb6930e3"
+  integrity sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
 "@fortawesome/free-solid-svg-icons@^5.15.4":
   version "5.15.4"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
   integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/react-fontawesome@^0.1.16":
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.16.tgz#ce7665490214e20f929368d6b65f68884a99276a"
+  integrity sha512-aLmzDwC9rEOAJv2UJdMns89VZR5Ry4IHu5dQQh24Z/lWKEm44lfQr1UNalZlkUaQN8d155tNh+CS7ntntj1VMA==
+  dependencies:
+    prop-types "^15.7.2"
 
 "@hapi/address@2.x.x":
   version "2.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9581,6 +9581,14 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
+react-tooltip@^4.2.21:
+  version "4.2.21"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.21.tgz#840123ed86cf33d50ddde8ec8813b2960bfded7f"
+  integrity sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
@@ -11428,6 +11436,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@^2.0.3:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,6 +1320,18 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-common-types@^0.2.36":
+  version "0.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
+  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+
+"@fortawesome/free-solid-svg-icons@^5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
+  integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"


### PR DESCRIPTION
### Added

- Added tooltip component to add extra info to a field. Added it to the client secret field for now to explain that it never leaves the browser, and it can also be filled in in Postman itself.

---

Ticket: https://jira.uitdatabank.be/browse/API-47

Note: I didn't change the extra info of the callback url field to a tooltip because the link to the docs wouldn't work in the tooltip.
