### PR TITLE
API-112 Add Search API and Taxonomy API

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.16",
-    "@publiqbe/openapi2postman": "^0.2.2",
+    "@publiqbe/openapi2postman": "0.3.0",
     "@tailwindcss/forms": "^0.3.4",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/src/Form.js
+++ b/src/Form.js
@@ -261,35 +261,39 @@ const Form = (props) => {
                   </div>
                 </div>
               )}
-              <div>
-                <input
-                  className="u-full-width"
-                  type="text"
-                  placeholder={`client id (${formData.environment} environment)`}
-                  value={formData.clientId}
-                  onChange={(e) => {
-                    setFormData({ ...formData, clientId: e.target.value });
-                    resetError();
-                  }}
-                />
-              </div>
-              <div style={{ position: 'relative' }}>
-                <input
-                  type="password"
-                  className="u-full-width"
-                  placeholder="client secret"
-                  value={formData.clientSecret}
-                  onChange={(e) => {
-                    setFormData({ ...formData, clientSecret: e.target.value });
-                    resetError();
-                  }}
-                />
-                <Tooltip
-                  text={
-                    'Your client secret never leaves your browser. You can also leave this empty and enter it in Postman itself as the "oauth2ClientSecret" variable.'
-                  }
-                />
-              </div>
+              {formData.authMethod !== 'none' && (
+                <div>
+                  <input
+                    className="u-full-width"
+                    type="text"
+                    placeholder={`client id (${formData.environment} environment)`}
+                    value={formData.clientId}
+                    onChange={(e) => {
+                      setFormData({ ...formData, clientId: e.target.value });
+                      resetError();
+                    }}
+                  />
+                </div>
+              )}
+              {formData.authMethod === 'token' && (
+                <div style={{ position: 'relative' }}>
+                  <input
+                    type="password"
+                    className="u-full-width"
+                    placeholder="client secret"
+                    value={formData.clientSecret}
+                    onChange={(e) => {
+                      setFormData({ ...formData, clientSecret: e.target.value });
+                      resetError();
+                    }}
+                  />
+                  <Tooltip
+                    text={
+                      'Your client secret never leaves your browser. You can also leave this empty and enter it in Postman itself as the "oauth2ClientSecret" variable.'
+                    }
+                  />
+                </div>
+              )}
               {hasAdvancedSettings && (
                 <AdvancedOptions>
                   <label htmlFor="environment">Environment</label>

--- a/src/Form.js
+++ b/src/Form.js
@@ -88,6 +88,37 @@ const Form = (props) => {
   const UITPAS_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitpas/nodes/reference/uitpas.json?deref=optimizedBundle`;
   const MPM_PARTNER_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}museumpassmusees/nodes/reference/partner-api.json?deref=optimizedBundle`;
 
+  let scheme;
+  let authMethod;
+  switch (formData.apiType) {
+    case 'udb-entry':
+      scheme = UDB_ENTRY_SCHEME_URL;
+      authMethod = 'token';
+      break;
+    case 'udb-search':
+      scheme = UDB_SEARCH_SCHEME_URL;
+      authMethod = 'x-client-id';
+      break;
+    case 'udb-taxonomy':
+      scheme = UDB_TAXONOMY_SCHEME_URL;
+      authMethod = 'none';
+      break;
+    case 'uitpas-api':
+      scheme = UITPAS_API_SCHEME_URL;
+      authMethod = 'token';
+      break;
+    case 'mpm-partner-api':
+      scheme = MPM_PARTNER_API_SCHEME_URL;
+      authMethod = 'token';
+      break;
+    case 'other':
+      scheme = formData.otherUrl;
+      authMethod = formData.authMethod;
+      break;
+    default:
+      scheme = UDB_ENTRY_SCHEME_URL;
+  }
+
   const handleSubmit = async () => {
     if (
       formData.apiType === 'other' &&
@@ -109,36 +140,6 @@ const Form = (props) => {
       return;
     }
 
-    let scheme;
-    let authMethod;
-    switch (formData.apiType) {
-      case 'udb-entry':
-        scheme = UDB_ENTRY_SCHEME_URL;
-        authMethod = 'token';
-        break;
-      case 'udb-search':
-        scheme = UDB_SEARCH_SCHEME_URL;
-        authMethod = 'x-client-id';
-        break;
-      case 'udb-taxonomy':
-        scheme = UDB_TAXONOMY_SCHEME_URL;
-        authMethod = 'none';
-        break;
-      case 'uitpas-api':
-        scheme = UITPAS_API_SCHEME_URL;
-        authMethod = 'token';
-        break;
-      case 'mpm-partner-api':
-        scheme = MPM_PARTNER_API_SCHEME_URL;
-        authMethod = 'token';
-        break;
-      case 'other':
-        scheme = formData.otherUrl;
-        authMethod = formData.authMethod;
-        break;
-      default:
-        scheme = UDB_ENTRY_SCHEME_URL;
-    }
     const environment = formData.environment || 'test';
     const baseUrl = '';
     const auth = {

--- a/src/Form.js
+++ b/src/Form.js
@@ -249,9 +249,6 @@ const Form = (props) => {
                     }}
                     id="authMethod"
                   >
-                    <option value="" disabled>
-                      Select authentication method
-                    </option>
                     <option value="none">None</option>
                     <option value="token">Token</option>
                     <option value="x-client-id">Client identification (x-client-id header)</option>

--- a/src/Form.js
+++ b/src/Form.js
@@ -43,17 +43,6 @@ const DownloadButton = styled.button`
   height: 50px;
 `;
 
-const InfoBox = styled.div`
-  background-color: #efefef;
-  padding: 15px;
-  border-radius: 5px;
-`;
-
-const Text = styled.p`
-  font-size: ${(props) => (props.size === 'small' ? '1.20rem' : '1.5rem')};
-  margin-bottom: 0;
-`;
-
 const Form = (props) => {
   const queryParams = new URLSearchParams(window.location.search);
 
@@ -65,7 +54,6 @@ const Form = (props) => {
     otherUrl: '',
     authMethod: '',
     tokenGrantType: 'client_credentials',
-    callbackUrl: '',
   });
 
   const DEFAULT_ERROR_TEXT = 'Something went wrong, please try again later';
@@ -144,7 +132,7 @@ const Form = (props) => {
       tokenGrantType: formData.tokenGrantType || 'client_credentials',
       clientId: formData.clientId,
       clientSecret: formData.clientSecret,
-      ...(formData.callbackUrl !== '' && { callbackUrl: formData.callbackUrl }),
+      callbackUrl: 'https://oauth.pstmn.io/v1/callback',
     };
     try {
       setLoading(true);
@@ -310,40 +298,6 @@ const Form = (props) => {
                       User access token
                     </option>
                   </select>
-                  {formData.tokenGrantType === 'authorization_code' && (
-                    <div>
-                      <input
-                        className="u-full-width"
-                        type="text"
-                        placeholder="callback url*"
-                        value={formData.callbackUrl}
-                        onChange={(e) => {
-                          setFormData({
-                            ...formData,
-                            callbackUrl: e.target.value,
-                          });
-                          resetError();
-                        }}
-                      />
-                      <InfoBox>
-                        <Text size="small">
-                          *URL to redirect back to after logging in. Postman
-                          will not show the actual page, but it is still
-                          required for a successful login flow. Has to be a URL
-                          that is configured to be allowed for the given client
-                          id. See the{' '}
-                          <a
-                            href="https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NTM5-user-access-token#client-configuration"
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            user access token documentation
-                          </a>{' '}
-                          for more information.
-                        </Text>
-                      </InfoBox>
-                    </div>
-                  )}
                 </div>
               )}
               {formData.apiType !== '' && (

--- a/src/Form.js
+++ b/src/Form.js
@@ -256,7 +256,7 @@ const Form = (props) => {
                   <input
                     className="u-full-width"
                     type="text"
-                    placeholder={`client id (${environment} environment)`}
+                    placeholder={`Client id (${environment} environment)`}
                     value={formData.clientId}
                     onChange={(e) => {
                       setFormData({ ...formData, clientId: e.target.value });
@@ -270,7 +270,7 @@ const Form = (props) => {
                   <input
                     type="password"
                     className="u-full-width"
-                    placeholder="client secret"
+                    placeholder="Client secret"
                     value={formData.clientSecret}
                     onChange={(e) => {
                       setFormData({ ...formData, clientSecret: e.target.value });

--- a/src/Form.js
+++ b/src/Form.js
@@ -52,11 +52,6 @@ const Form = (props) => {
     'https://stoplight.io/api/v1/projects/publiq/';
   const PUBLIQ_GITHUBUSERCONTENT_SCHEME =
     'https://raw.githubusercontent.com/cultuurnet/apidocs/';
-  const UDB_ENTRY_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/entry.json?deref=optimizedBundle`;
-  const UDB_SEARCH_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/search.json?deref=optimizedBundle`;
-  const UDB_TAXONOMY_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/taxonomy.json?deref=optimizedBundle`;
-  const UITPAS_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitpas/nodes/reference/uitpas.json?deref=optimizedBundle`;
-  const MPM_PARTNER_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}museumpassmusees/nodes/reference/partner-api.json?deref=optimizedBundle`;
 
   const allEnvironments = [
     {
@@ -81,19 +76,19 @@ const Form = (props) => {
       defaultEnvironment: '',
     },
     'udb-entry': {
-      scheme: UDB_ENTRY_SCHEME_URL,
+      scheme: `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/entry.json?deref=optimizedBundle`,
       authMethod: 'token',
       environments: allEnvironments,
       defaultEnvironment: 'test',
     },
     'udb-search': {
-      scheme: UDB_SEARCH_SCHEME_URL,
+      scheme: `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/search.json?deref=optimizedBundle`,
       authMethod: 'x-client-id',
       environments: allEnvironments,
       defaultEnvironment: 'test',
     },
     'udb-taxonomy': {
-      scheme: UDB_TAXONOMY_SCHEME_URL,
+      scheme: `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/taxonomy.json?deref=optimizedBundle`,
       authMethod: 'none',
       environments: allEnvironments.filter(
         (environment) => environment.value === 'prod'
@@ -101,13 +96,13 @@ const Form = (props) => {
       defaultEnvironment: 'prod',
     },
     'uitpas-api': {
-      scheme: UITPAS_API_SCHEME_URL,
+      scheme: `${PUBLIQ_STOPLIGHT_SCHEME}uitpas/nodes/reference/uitpas.json?deref=optimizedBundle`,
       authMethod: 'token',
       environments: allEnvironments,
       defaultEnvironment: 'test',
     },
     'mpm-partner-api': {
-      scheme: MPM_PARTNER_API_SCHEME_URL,
+      scheme: `${PUBLIQ_STOPLIGHT_SCHEME}museumpassmusees/nodes/reference/partner-api.json?deref=optimizedBundle`,
       authMethod: 'token',
       environments: allEnvironments,
       defaultEnvironment: 'test',

--- a/src/Form.js
+++ b/src/Form.js
@@ -6,21 +6,6 @@ import { HowTo } from './components/HowTo';
 import { Spinner } from './components/Spinner';
 import { Tooltip } from './components/Tooltip';
 
-const ENVIRONMENTS = [
-  {
-    label: 'Acceptance',
-    value: 'acc',
-  },
-  {
-    label: 'Testing',
-    value: 'test',
-  },
-  {
-    label: 'Production',
-    value: 'prod',
-  },
-];
-
 const FormWrapper = styled.div`
   display: flex;
   justify-content: center;
@@ -49,7 +34,7 @@ const Form = (props) => {
   const [formData, setFormData] = useState({
     clientId: '',
     clientSecret: '',
-    environment: 'test',
+    environment: '',
     apiType: queryParams.get('api') ?? '',
     otherUrl: '',
     authMethod: '',
@@ -75,6 +60,21 @@ const Form = (props) => {
 
   let scheme;
   let authMethod;
+  let defaultEnvironment = 'test';
+  let environments = [
+    {
+      label: 'Acceptance',
+      value: 'acc',
+    },
+    {
+      label: 'Testing',
+      value: 'test',
+    },
+    {
+      label: 'Production',
+      value: 'prod',
+    },
+  ];
   switch (formData.apiType) {
     case 'udb-entry':
       scheme = UDB_ENTRY_SCHEME_URL;
@@ -87,6 +87,13 @@ const Form = (props) => {
     case 'udb-taxonomy':
       scheme = UDB_TAXONOMY_SCHEME_URL;
       authMethod = 'none';
+      defaultEnvironment = 'prod';
+      environments = [
+        {
+          label: 'Production',
+          value: 'prod',
+        },
+      ];
       break;
     case 'uitpas-api':
       scheme = UITPAS_API_SCHEME_URL;
@@ -103,6 +110,8 @@ const Form = (props) => {
     default:
       scheme = UDB_ENTRY_SCHEME_URL;
   }
+
+  const environment = formData.environment || defaultEnvironment;
 
   const handleSubmit = async () => {
     if (
@@ -125,7 +134,6 @@ const Form = (props) => {
       return;
     }
 
-    const environment = formData.environment || 'test';
     const baseUrl = '';
     const auth = {
       authMethod: authMethod,
@@ -305,14 +313,14 @@ const Form = (props) => {
                   <label htmlFor="environment">Environment</label>
                   <select
                     className="u-full-width"
-                    value={formData.environment}
+                    value={environment}
                     onChange={(e) => {
                       setFormData({ ...formData, environment: e.target.value });
                       resetError();
                     }}
                     id="environment"
                   >
-                    {ENVIRONMENTS.map((environment) => (
+                    {environments.map((environment) => (
                       <option value={environment.value}>
                         {environment.label}
                       </option>

--- a/src/Form.js
+++ b/src/Form.js
@@ -222,7 +222,7 @@ const Form = (props) => {
                   <input
                     className="u-full-width"
                     type="text"
-                    placeholder="openapi file url"
+                    placeholder="OpenAPI file url"
                     value={formData.otherUrl}
                     onChange={(e) => {
                       setFormData({ ...formData, otherUrl: e.target.value });

--- a/src/Form.js
+++ b/src/Form.js
@@ -256,7 +256,7 @@ const Form = (props) => {
                   <input
                     className="u-full-width"
                     type="text"
-                    placeholder={`client id (${formData.environment} environment)`}
+                    placeholder={`client id (${environment} environment)`}
                     value={formData.clientId}
                     onChange={(e) => {
                       setFormData({ ...formData, clientId: e.target.value });

--- a/src/Form.js
+++ b/src/Form.js
@@ -58,10 +58,7 @@ const Form = (props) => {
   const UITPAS_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitpas/nodes/reference/uitpas.json?deref=optimizedBundle`;
   const MPM_PARTNER_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}museumpassmusees/nodes/reference/partner-api.json?deref=optimizedBundle`;
 
-  let scheme;
-  let authMethod;
-  let defaultEnvironment = 'test';
-  let environments = [
+  const allEnvironments = [
     {
       label: 'Acceptance',
       value: 'acc',
@@ -75,42 +72,55 @@ const Form = (props) => {
       value: 'prod',
     },
   ];
-  switch (formData.apiType) {
-    case 'udb-entry':
-      scheme = UDB_ENTRY_SCHEME_URL;
-      authMethod = 'token';
-      break;
-    case 'udb-search':
-      scheme = UDB_SEARCH_SCHEME_URL;
-      authMethod = 'x-client-id';
-      break;
-    case 'udb-taxonomy':
-      scheme = UDB_TAXONOMY_SCHEME_URL;
-      authMethod = 'none';
-      defaultEnvironment = 'prod';
-      environments = [
-        {
-          label: 'Production',
-          value: 'prod',
-        },
-      ];
-      break;
-    case 'uitpas-api':
-      scheme = UITPAS_API_SCHEME_URL;
-      authMethod = 'token';
-      break;
-    case 'mpm-partner-api':
-      scheme = MPM_PARTNER_API_SCHEME_URL;
-      authMethod = 'token';
-      break;
-    case 'other':
-      scheme = formData.otherUrl;
-      authMethod = formData.authMethod;
-      break;
-    default:
-      scheme = UDB_ENTRY_SCHEME_URL;
+
+  const apiConfig = {
+    'none': {
+      scheme: '',
+      authMethod: 'none',
+      environments: [],
+      defaultEnvironment: '',
+    },
+    'udb-entry': {
+      scheme: UDB_ENTRY_SCHEME_URL,
+      authMethod: 'token',
+      environments: allEnvironments,
+      defaultEnvironment: 'test',
+    },
+    'udb-search': {
+      scheme: UDB_SEARCH_SCHEME_URL,
+      authMethod: 'x-client-id',
+      environments: allEnvironments,
+      defaultEnvironment: 'test',
+    },
+    'udb-taxonomy': {
+      scheme: UDB_TAXONOMY_SCHEME_URL,
+      authMethod: 'none',
+      environments: allEnvironments.filter(
+        (environment) => environment.value === 'prod'
+      ),
+      defaultEnvironment: 'prod',
+    },
+    'uitpas-api': {
+      scheme: UITPAS_API_SCHEME_URL,
+      authMethod: 'token',
+      environments: allEnvironments,
+      defaultEnvironment: 'test',
+    },
+    'mpm-partner-api': {
+      scheme: MPM_PARTNER_API_SCHEME_URL,
+      authMethod: 'token',
+      environments: allEnvironments,
+      defaultEnvironment: 'test',
+    },
+    'other': {
+      scheme: formData.otherUrl,
+      authMethod: formData.authMethod,
+      environments: allEnvironments,
+      defaultEnvironment: 'test',
+    }
   }
 
+  const { scheme, authMethod, defaultEnvironment, environments } = apiConfig[formData.apiType || 'none'];
   const environment = formData.environment || defaultEnvironment;
 
   const handleSubmit = async () => {

--- a/src/Form.js
+++ b/src/Form.js
@@ -316,58 +316,62 @@ const Form = (props) => {
                       </option>
                     ))}
                   </select>
-                  <label htmlFor="tokenGrantType">Token type </label>
-                  <select
-                    className="u-full-width"
-                    value={formData.tokenGrantType}
-                    onChange={(e) => {
-                      setFormData({
-                        ...formData,
-                        tokenGrantType: e.target.value,
-                      });
-                      resetError();
-                    }}
-                    id="tokenGrantType"
-                  >
-                    <option value="client_credentials">
-                      Client access token
-                    </option>
-                    <option value="authorization_code">
-                      User access token
-                    </option>
-                  </select>
-                  {formData.tokenGrantType === 'authorization_code' && (
+                  {authMethod === 'token' && (
                     <div>
-                      <input
+                      <label htmlFor="tokenGrantType">Token type</label>
+                      <select
                         className="u-full-width"
-                        type="text"
-                        placeholder="callback url*"
-                        value={formData.callbackUrl}
+                        value={formData.tokenGrantType}
                         onChange={(e) => {
                           setFormData({
                             ...formData,
-                            callbackUrl: e.target.value,
+                            tokenGrantType: e.target.value,
                           });
                           resetError();
                         }}
-                      />
-                      <InfoBox>
-                        <Text size="small">
-                          *URL to redirect back to after logging in. Postman
-                          will not show the actual page, but it is still
-                          required for a successful login flow. Has to be a URL
-                          that is configured to be allowed for the given client
-                          id. See the{' '}
-                          <a
-                            href="https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NTM5-user-access-token#client-configuration"
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            user access token documentation
-                          </a>{' '}
-                          for more information.
-                        </Text>
-                      </InfoBox>
+                        id="tokenGrantType"
+                      >
+                        <option value="client_credentials">
+                          Client access token
+                        </option>
+                        <option value="authorization_code">
+                          User access token
+                        </option>
+                      </select>
+                      {formData.tokenGrantType === 'authorization_code' && (
+                        <div>
+                          <input
+                            className="u-full-width"
+                            type="text"
+                            placeholder="callback url*"
+                            value={formData.callbackUrl}
+                            onChange={(e) => {
+                              setFormData({
+                                ...formData,
+                                callbackUrl: e.target.value,
+                              });
+                              resetError();
+                            }}
+                          />
+                          <InfoBox>
+                            <Text size="small">
+                              *URL to redirect back to after logging in. Postman
+                              will not show the actual page, but it is still
+                              required for a successful login flow. Has to be a URL
+                              that is configured to be allowed for the given client
+                              id. See the{' '}
+                              <a
+                                href="https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NTM5-user-access-token#client-configuration"
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                user access token documentation
+                              </a>{' '}
+                              for more information.
+                            </Text>
+                          </InfoBox>
+                        </div>
+                      )}
                     </div>
                   )}
                 </AdvancedOptions>

--- a/src/Form.js
+++ b/src/Form.js
@@ -213,7 +213,7 @@ const Form = (props) => {
                   <input
                     className="u-full-width"
                     type="text"
-                    placeholder="url"
+                    placeholder="openapi file url"
                     value={formData.otherUrl}
                     onChange={(e) => {
                       setFormData({ ...formData, otherUrl: e.target.value });

--- a/src/Form.js
+++ b/src/Form.js
@@ -231,6 +231,26 @@ const Form = (props) => {
                   />
                 </div>
               )}
+              {formData.apiType !== '' && (
+                <div>
+                  <label htmlFor="environment">Environment</label>
+                  <select
+                    className="u-full-width"
+                    value={environment}
+                    onChange={(e) => {
+                      setFormData({ ...formData, environment: e.target.value });
+                      resetError();
+                    }}
+                    id="environment"
+                  >
+                    {environments.map((environment) => (
+                      <option value={environment.value}>
+                        {environment.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <div>
                 {(authMethod !== 'none' || formData.apiType === 'other') && (
                   <label htmlFor="authMethod">Authentication</label>
@@ -305,26 +325,6 @@ const Form = (props) => {
                     <option value="authorization_code">
                       User access token
                     </option>
-                  </select>
-                </div>
-              )}
-              {formData.apiType !== '' && (
-                <div>
-                  <label htmlFor="environment">Environment</label>
-                  <select
-                    className="u-full-width"
-                    value={environment}
-                    onChange={(e) => {
-                      setFormData({ ...formData, environment: e.target.value });
-                      resetError();
-                    }}
-                    id="environment"
-                  >
-                    {environments.map((environment) => (
-                      <option value={environment.value}>
-                        {environment.label}
-                      </option>
-                    ))}
                   </select>
                 </div>
               )}

--- a/src/Form.js
+++ b/src/Form.js
@@ -43,8 +43,6 @@ const DownloadButton = styled.button`
   height: 50px;
 `;
 
-const AdvancedOptions = styled.div``;
-
 const InfoBox = styled.div`
   background-color: #efefef;
   padding: 15px;
@@ -73,7 +71,6 @@ const Form = (props) => {
   const DEFAULT_ERROR_TEXT = 'Something went wrong, please try again later';
 
   const [loading, setLoading] = useState(false);
-  const [hasAdvancedSettings, setHasAdvancedSettings] = useState(false);
   const [hasDownloadStarted, setHasDownloadStarted] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [errorText, setErrorText] = useState(DEFAULT_ERROR_TEXT);
@@ -183,10 +180,6 @@ const Form = (props) => {
   const restartFlow = () => {
     setHasDownloadStarted(false);
     props.onDownloadCompleted(false);
-  };
-
-  const toggleAdvancedOptions = () => {
-    setHasAdvancedSettings(!hasAdvancedSettings);
   };
 
   return (
@@ -356,8 +349,8 @@ const Form = (props) => {
                   )}
                 </div>
               )}
-              {hasAdvancedSettings && (
-                <AdvancedOptions>
+              {formData.apiType !== '' && (
+                <div>
                   <label htmlFor="environment">Environment</label>
                   <select
                     className="u-full-width"
@@ -374,11 +367,8 @@ const Form = (props) => {
                       </option>
                     ))}
                   </select>
-                </AdvancedOptions>
+                </div>
               )}
-              <LinkButton onClick={toggleAdvancedOptions}>
-                {hasAdvancedSettings ? 'Hide' : 'Show'} advanced options
-              </LinkButton>
               <DownloadButton onClick={handleSubmit} className="button-primary">
                 Download
               </DownloadButton>

--- a/src/Form.js
+++ b/src/Form.js
@@ -188,35 +188,6 @@ const Form = (props) => {
           ) : (
             <FormWrapper key="form-wrapper">
               <div>
-                <input
-                  className="u-full-width"
-                  type="text"
-                  placeholder={`client id (${formData.environment} environment)`}
-                  value={formData.clientId}
-                  onChange={(e) => {
-                    setFormData({ ...formData, clientId: e.target.value });
-                    resetError();
-                  }}
-                />
-              </div>
-              <div style={{ position: 'relative' }}>
-                <input
-                  type="password"
-                  className="u-full-width"
-                  placeholder="client secret"
-                  value={formData.clientSecret}
-                  onChange={(e) => {
-                    setFormData({ ...formData, clientSecret: e.target.value });
-                    resetError();
-                  }}
-                />
-                <Tooltip
-                  text={
-                    'Your client secret never leaves your browser. You can also leave this empty and enter it in Postman itself as the "oauth2ClientSecret" variable.'
-                  }
-                />
-              </div>
-              <div>
                 <select
                   className="u-full-width"
                   value={formData.apiType}
@@ -251,6 +222,35 @@ const Form = (props) => {
                   />
                 </div>
               )}
+              <div>
+                <input
+                  className="u-full-width"
+                  type="text"
+                  placeholder={`client id (${formData.environment} environment)`}
+                  value={formData.clientId}
+                  onChange={(e) => {
+                    setFormData({ ...formData, clientId: e.target.value });
+                    resetError();
+                  }}
+                />
+              </div>
+              <div style={{ position: 'relative' }}>
+                <input
+                  type="password"
+                  className="u-full-width"
+                  placeholder="client secret"
+                  value={formData.clientSecret}
+                  onChange={(e) => {
+                    setFormData({ ...formData, clientSecret: e.target.value });
+                    resetError();
+                  }}
+                />
+                <Tooltip
+                  text={
+                    'Your client secret never leaves your browser. You can also leave this empty and enter it in Postman itself as the "oauth2ClientSecret" variable.'
+                  }
+                />
+              </div>
               {hasAdvancedSettings && (
                 <AdvancedOptions>
                   <label htmlFor="environment">Environment</label>

--- a/src/Form.js
+++ b/src/Form.js
@@ -267,7 +267,9 @@ const Form = (props) => {
                   >
                     <option value="none">None</option>
                     <option value="token">Token</option>
-                    <option value="x-client-id">Client identification (x-client-id header)</option>
+                    <option value="x-client-id">
+                      Client identification (x-client-id header)
+                    </option>
                   </select>
                 )}
               </div>
@@ -293,7 +295,10 @@ const Form = (props) => {
                     placeholder={`Client secret (${environment} environment)`}
                     value={formData.clientSecret}
                     onChange={(e) => {
-                      setFormData({ ...formData, clientSecret: e.target.value });
+                      setFormData({
+                        ...formData,
+                        clientSecret: e.target.value,
+                      });
                       resetError();
                     }}
                   />

--- a/src/Form.js
+++ b/src/Form.js
@@ -86,7 +86,7 @@ const Form = (props) => {
   const MPM_PARTNER_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}museumpassmusees/nodes/reference/partner-api.json?deref=optimizedBundle`;
 
   let scheme;
-  let authMethod = 'none';
+  let authMethod;
   switch (formData.apiType) {
     case 'udb-entry':
       scheme = UDB_ENTRY_SCHEME_URL;
@@ -258,7 +258,7 @@ const Form = (props) => {
                   </select>
                 )}
               </div>
-              {(authMethod !== 'none') && (
+              {(authMethod === 'token' || authMethod === 'x-client-id') && (
                 <div>
                   <input
                     className="u-full-width"

--- a/src/Form.js
+++ b/src/Form.js
@@ -262,7 +262,7 @@ const Form = (props) => {
                   </div>
                 </div>
               )}
-              {formData.authMethod !== 'none' && (
+              {(authMethod === 'token' || authMethod === 'x-client-id') && (
                 <div>
                   <input
                     className="u-full-width"
@@ -276,7 +276,7 @@ const Form = (props) => {
                   />
                 </div>
               )}
-              {formData.authMethod === 'token' && (
+              {authMethod === 'token' && (
                 <div style={{ position: 'relative' }}>
                   <input
                     type="password"

--- a/src/Form.js
+++ b/src/Form.js
@@ -82,6 +82,8 @@ const Form = (props) => {
   const PUBLIQ_GITHUBUSERCONTENT_SCHEME =
     'https://raw.githubusercontent.com/cultuurnet/apidocs/';
   const UDB_ENTRY_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/entry.json?deref=optimizedBundle`;
+  const UDB_SEARCH_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/search.json?deref=optimizedBundle`;
+  const UDB_TAXONOMY_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/taxonomy.json?deref=optimizedBundle`;
   const UITPAS_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}uitpas/nodes/reference/uitpas.json?deref=optimizedBundle`;
   const MPM_PARTNER_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}museumpassmusees/nodes/reference/partner-api.json?deref=optimizedBundle`;
 
@@ -110,6 +112,12 @@ const Form = (props) => {
     switch (formData.apiType) {
       case 'udb-entry':
         scheme = UDB_ENTRY_SCHEME_URL;
+        break;
+      case 'udb-search':
+        scheme = UDB_SEARCH_SCHEME_URL;
+        break;
+      case 'udb-taxonomy':
+        scheme = UDB_TAXONOMY_SCHEME_URL;
         break;
       case 'uitpas-api':
         scheme = UITPAS_API_SCHEME_URL;
@@ -201,6 +209,8 @@ const Form = (props) => {
                     Select API
                   </option>
                   <option value="udb-entry">UiTdatabank Entry API</option>
+                  <option value="udb-search">UiTdatabank Search API</option>
+                  <option value="udb-taxonomy">UiTdatabank Taxonomy API</option>
                   <option value="uitpas-api">UiTPAS API</option>
                   <option value="mpm-partner-api">
                     museumPASSmusées Partner API

--- a/src/Form.js
+++ b/src/Form.js
@@ -290,7 +290,7 @@ const Form = (props) => {
                   <input
                     type="password"
                     className="u-full-width"
-                    placeholder="Client secret"
+                    placeholder={`Client secret (${environment} environment)`}
                     value={formData.clientSecret}
                     onChange={(e) => {
                       setFormData({ ...formData, clientSecret: e.target.value });

--- a/src/Form.js
+++ b/src/Form.js
@@ -230,38 +230,41 @@ const Form = (props) => {
               </div>
               {formData.apiType === 'other' && (
                 <div>
-                  <div>
-                    <input
-                      className="u-full-width"
-                      type="text"
-                      placeholder="openapi file url"
-                      value={formData.otherUrl}
-                      onChange={(e) => {
-                        setFormData({ ...formData, otherUrl: e.target.value });
-                        resetError();
-                      }}
-                    />
-                  </div>
-                  <div>
-                    <select
-                      className="u-full-width"
-                      value={formData.authMethod}
-                      onChange={(e) => {
-                        setFormData({ ...formData, authMethod: e.target.value });
-                        resetError();
-                      }}
-                      id="authMethod"
-                    >
-                      <option value="" disabled>
-                        Select authentication method
-                      </option>
-                      <option value="none">No authentication</option>
-                      <option value="token">Token</option>
-                      <option value="x-client-id">Client identification (x-client-id header)</option>
-                    </select>
-                  </div>
+                  <input
+                    className="u-full-width"
+                    type="text"
+                    placeholder="openapi file url"
+                    value={formData.otherUrl}
+                    onChange={(e) => {
+                      setFormData({ ...formData, otherUrl: e.target.value });
+                      resetError();
+                    }}
+                  />
                 </div>
               )}
+              <div>
+                {authMethod !== 'none' && (
+                  <label htmlFor="authMethod">Authentication</label>
+                )}
+                {formData.apiType === 'other' && (
+                  <select
+                    className="u-full-width"
+                    value={formData.authMethod}
+                    onChange={(e) => {
+                      setFormData({ ...formData, authMethod: e.target.value });
+                      resetError();
+                    }}
+                    id="authMethod"
+                  >
+                    <option value="" disabled>
+                      Select authentication method
+                    </option>
+                    <option value="none">None</option>
+                    <option value="token">Token</option>
+                    <option value="x-client-id">Client identification (x-client-id header)</option>
+                  </select>
+                )}
+              </div>
               {(authMethod !== 'none') && (
                 <div>
                   <input

--- a/src/Form.js
+++ b/src/Form.js
@@ -65,6 +65,7 @@ const Form = (props) => {
     environment: 'test',
     apiType: queryParams.get('api') ?? '',
     otherUrl: '',
+    authMethod: '',
     tokenGrantType: 'client_credentials',
     callbackUrl: '',
   });
@@ -109,24 +110,31 @@ const Form = (props) => {
     }
 
     let scheme;
+    let authMethod;
     switch (formData.apiType) {
       case 'udb-entry':
         scheme = UDB_ENTRY_SCHEME_URL;
+        authMethod = 'token';
         break;
       case 'udb-search':
         scheme = UDB_SEARCH_SCHEME_URL;
+        authMethod = 'x-client-id';
         break;
       case 'udb-taxonomy':
         scheme = UDB_TAXONOMY_SCHEME_URL;
+        authMethod = 'none';
         break;
       case 'uitpas-api':
         scheme = UITPAS_API_SCHEME_URL;
+        authMethod = 'token';
         break;
       case 'mpm-partner-api':
         scheme = MPM_PARTNER_API_SCHEME_URL;
+        authMethod = 'token';
         break;
       case 'other':
         scheme = formData.otherUrl;
+        authMethod = formData.authMethod;
         break;
       default:
         scheme = UDB_ENTRY_SCHEME_URL;
@@ -134,6 +142,7 @@ const Form = (props) => {
     const environment = formData.environment || 'test';
     const baseUrl = '';
     const auth = {
+      authMethod: authMethod,
       tokenGrantType: formData.tokenGrantType || 'client_credentials',
       clientId: formData.clientId,
       clientSecret: formData.clientSecret,
@@ -220,16 +229,36 @@ const Form = (props) => {
               </div>
               {formData.apiType === 'other' && (
                 <div>
-                  <input
-                    className="u-full-width"
-                    type="text"
-                    placeholder="openapi file url"
-                    value={formData.otherUrl}
-                    onChange={(e) => {
-                      setFormData({ ...formData, otherUrl: e.target.value });
-                      resetError();
-                    }}
-                  />
+                  <div>
+                    <input
+                      className="u-full-width"
+                      type="text"
+                      placeholder="openapi file url"
+                      value={formData.otherUrl}
+                      onChange={(e) => {
+                        setFormData({ ...formData, otherUrl: e.target.value });
+                        resetError();
+                      }}
+                    />
+                  </div>
+                  <div>
+                    <select
+                      className="u-full-width"
+                      value={formData.authMethod}
+                      onChange={(e) => {
+                        setFormData({ ...formData, authMethod: e.target.value });
+                        resetError();
+                      }}
+                      id="authMethod"
+                    >
+                      <option value="" disabled>
+                        Select authentication method
+                      </option>
+                      <option value="none">None</option>
+                      <option value="token">Token</option>
+                      <option value="x-client-id">Client identification (x-client-id header)</option>
+                    </select>
+                  </div>
                 </div>
               )}
               <div>

--- a/src/Form.js
+++ b/src/Form.js
@@ -89,7 +89,7 @@ const Form = (props) => {
   const MPM_PARTNER_API_SCHEME_URL = `${PUBLIQ_STOPLIGHT_SCHEME}museumpassmusees/nodes/reference/partner-api.json?deref=optimizedBundle`;
 
   let scheme;
-  let authMethod;
+  let authMethod = 'none';
   switch (formData.apiType) {
     case 'udb-entry':
       scheme = UDB_ENTRY_SCHEME_URL;
@@ -262,7 +262,7 @@ const Form = (props) => {
                   </div>
                 </div>
               )}
-              {(authMethod === 'token' || authMethod === 'x-client-id') && (
+              {(authMethod !== 'none') && (
                 <div>
                   <input
                     className="u-full-width"

--- a/src/Form.js
+++ b/src/Form.js
@@ -243,7 +243,7 @@ const Form = (props) => {
                 </div>
               )}
               <div>
-                {authMethod !== 'none' && (
+                {(authMethod !== 'none' || formData.apiType === 'other') && (
                   <label htmlFor="authMethod">Authentication</label>
                 )}
                 {formData.apiType === 'other' && (

--- a/src/Form.js
+++ b/src/Form.js
@@ -224,7 +224,7 @@ const Form = (props) => {
                   <option value="mpm-partner-api">
                     museumPASSmusées Partner API
                   </option>
-                  <option value="other">Other...</option>
+                  <option value="other">Other API...</option>
                 </select>
               </div>
               {formData.apiType === 'other' && (
@@ -254,7 +254,7 @@ const Form = (props) => {
                       <option value="" disabled>
                         Select authentication method
                       </option>
-                      <option value="none">None</option>
+                      <option value="none">No authentication</option>
                       <option value="token">Token</option>
                       <option value="x-client-id">Client identification (x-client-id header)</option>
                     </select>

--- a/src/Form.js
+++ b/src/Form.js
@@ -69,7 +69,7 @@ const Form = (props) => {
   ];
 
   const apiConfig = {
-    'none': {
+    none: {
       scheme: '',
       authMethod: 'none',
       environments: [],
@@ -91,7 +91,7 @@ const Form = (props) => {
       scheme: `${PUBLIQ_STOPLIGHT_SCHEME}uitdatabank/nodes/reference/taxonomy.json?deref=optimizedBundle`,
       authMethod: 'none',
       environments: allEnvironments.filter(
-        (environment) => environment.value === 'prod'
+        (environment) => environment.value === 'prod',
       ),
       defaultEnvironment: 'prod',
     },
@@ -107,15 +107,16 @@ const Form = (props) => {
       environments: allEnvironments,
       defaultEnvironment: 'test',
     },
-    'other': {
+    other: {
       scheme: formData.otherUrl,
       authMethod: formData.authMethod,
       environments: allEnvironments,
       defaultEnvironment: 'test',
-    }
-  }
+    },
+  };
 
-  const { scheme, authMethod, defaultEnvironment, environments } = apiConfig[formData.apiType || 'none'];
+  const { scheme, authMethod, defaultEnvironment, environments } =
+    apiConfig[formData.apiType || 'none'];
   const environment = formData.environment || defaultEnvironment;
 
   const handleSubmit = async () => {

--- a/src/Form.js
+++ b/src/Form.js
@@ -298,6 +298,64 @@ const Form = (props) => {
                   />
                 </div>
               )}
+              {authMethod === 'token' && (
+                <div>
+                  <label htmlFor="tokenGrantType">Token type</label>
+                  <select
+                    className="u-full-width"
+                    value={formData.tokenGrantType}
+                    onChange={(e) => {
+                      setFormData({
+                        ...formData,
+                        tokenGrantType: e.target.value,
+                      });
+                      resetError();
+                    }}
+                    id="tokenGrantType"
+                  >
+                    <option value="client_credentials">
+                      Client access token
+                    </option>
+                    <option value="authorization_code">
+                      User access token
+                    </option>
+                  </select>
+                  {formData.tokenGrantType === 'authorization_code' && (
+                    <div>
+                      <input
+                        className="u-full-width"
+                        type="text"
+                        placeholder="callback url*"
+                        value={formData.callbackUrl}
+                        onChange={(e) => {
+                          setFormData({
+                            ...formData,
+                            callbackUrl: e.target.value,
+                          });
+                          resetError();
+                        }}
+                      />
+                      <InfoBox>
+                        <Text size="small">
+                          *URL to redirect back to after logging in. Postman
+                          will not show the actual page, but it is still
+                          required for a successful login flow. Has to be a URL
+                          that is configured to be allowed for the given client
+                          id. See the{' '}
+                          <a
+                            href="https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NTM5-user-access-token#client-configuration"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            user access token documentation
+                          </a>{' '}
+                          for more information.
+                        </Text>
+                      </InfoBox>
+                    </div>
+                  )}
+                </div>
+              )}
               {hasAdvancedSettings && (
                 <AdvancedOptions>
                   <label htmlFor="environment">Environment</label>
@@ -316,64 +374,6 @@ const Form = (props) => {
                       </option>
                     ))}
                   </select>
-                  {authMethod === 'token' && (
-                    <div>
-                      <label htmlFor="tokenGrantType">Token type</label>
-                      <select
-                        className="u-full-width"
-                        value={formData.tokenGrantType}
-                        onChange={(e) => {
-                          setFormData({
-                            ...formData,
-                            tokenGrantType: e.target.value,
-                          });
-                          resetError();
-                        }}
-                        id="tokenGrantType"
-                      >
-                        <option value="client_credentials">
-                          Client access token
-                        </option>
-                        <option value="authorization_code">
-                          User access token
-                        </option>
-                      </select>
-                      {formData.tokenGrantType === 'authorization_code' && (
-                        <div>
-                          <input
-                            className="u-full-width"
-                            type="text"
-                            placeholder="callback url*"
-                            value={formData.callbackUrl}
-                            onChange={(e) => {
-                              setFormData({
-                                ...formData,
-                                callbackUrl: e.target.value,
-                              });
-                              resetError();
-                            }}
-                          />
-                          <InfoBox>
-                            <Text size="small">
-                              *URL to redirect back to after logging in. Postman
-                              will not show the actual page, but it is still
-                              required for a successful login flow. Has to be a URL
-                              that is configured to be allowed for the given client
-                              id. See the{' '}
-                              <a
-                                href="https://docs.publiq.be/docs/authentication/ZG9jOjExODE5NTM5-user-access-token#client-configuration"
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                user access token documentation
-                              </a>{' '}
-                              for more information.
-                            </Text>
-                          </InfoBox>
-                        </div>
-                      )}
-                    </div>
-                  )}
                 </AdvancedOptions>
               )}
               <LinkButton onClick={toggleAdvancedOptions}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,10 +1622,10 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@publiqbe/openapi2postman@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@publiqbe/openapi2postman/-/openapi2postman-0.2.2.tgz#84da6d4222b38cecd1821222dda36ba0cddd099d"
-  integrity sha512-b6flIl2WXTYwbk1aIuU10oEYJpd2KEmY+HVuX36xONCanBNCZy4NH8wzHQbhcBWolxhooFkQk3sbXeqiBhIBOA==
+"@publiqbe/openapi2postman@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@publiqbe/openapi2postman/-/openapi2postman-0.3.0.tgz#d73d119049cf416e0bb8c65135a2cf1b11f1e943"
+  integrity sha512-poyoJ6Dg2K7GPYMeNPQj66X5RjA2AsqJMeF1/sgrcGjhhd2W4ndf8yvhI5RW8gdOCtFsYmcuhslyZHpjkw5a0A==
   dependencies:
     "@apidevtools/json-schema-ref-parser" "^9.0.9"
     openapi-to-postmanv2 "^2.12.0"


### PR DESCRIPTION
### Added

- Added `UiTdatabank Search API` option
- Added `UiTdatabank Taxonomy API` option
- Added support for different authentication methods (depending on the API)

### Changed

- Updated `@publiqbe/openapi2postman` to `v0.3.0`
- The order of form fields is updated to reflect the different possible authentication methods:
  - The API field is now first as it influences the next fields to show (and their possible values)
  - Second is the environment field, as it is applicable to every API but has different values per API (the Taxonomy API has no acc/test environment)
  - Third are the authentication fields. When Taxonomy API is chosen none are shown. When Search API is chosen only the client id field is shown. For the remaining APIs the client id & client secret fields are shown, as well as the field to select the token type to show.
  - When "Other API..." is chosen as API the field to enter the OpenAPI file URL is shown (as before), and you can now manually specify the authentication method (None/Token/Client identification). Rest of the fields are the same as for the other APIs (depending on the authentication method)

### Removed

- The "advanced settings" toggle is removed. It was useful to hide some fields so that the form was not overwhelming when the page loaded. But now we start of with only 1 field anyway. And the advanced settings were either not that advanced (environment field) or only relevant to a specific auth method (token type - which is hidden anyway now when not relevant)
- The callback URL field (previously shown when selecting "User access tokens" as token type) is removed, and the `callbackUrl` is now always set to a hardcoded value that should work for all clients created by publiq platform. In other cases, you can always update the variable value in the imported Postman collection.

### Fixed

- The update of `@publiqbe/openapi2postman` fixes a crash when trying to download the Search API collection, caused by a circular reference in the OpenAPI file (which is technically valid but the conversion script had some trouble with it)

---
Ticket: https://jira.uitdatabank.be/browse/API-112
